### PR TITLE
Simplify profile README to a minimal text-only layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Soma Sekimoto
 
-Full-stack engineer — Web3, cryptography, and privacy tech.
+Full-stack engineer — decentralized systems, personal knowledge tools, and AI-powered automation.
 
 **Now**
-Fully Homomorphic Encryption (TFHE) · Zero-Knowledge Proofs
+- [Monas](https://github.com/Monas-project/monas) — decentralized personal data store (Rust)
+- Obsidian × AI — [obsidian-clippings-dedupe](https://github.com/somasekimoto/obsidian-clippings-dedupe), X→Obsidian auto-archiving, building a personal knowledge base AI can work with
+- Automating my solo business (accounting, ops) with AI agents
 
 **Stack**
-Go · TypeScript · Rust · Solidity · React / Next.js · Docker / K8s
+Rust · TypeScript · Go · Python · React / Next.js · Cloudflare Workers · Docker / K8s
 
-**Writing**
-[Zenn](https://zenn.dev/somasekimoto) · [Qiita](https://qiita.com/soma_sekimoto)
+**Links**
+[X](https://x.com/somaseki) · [Zenn](https://zenn.dev/somasekimoto) · [Qiita](https://qiita.com/soma_sekimoto)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Full-stack engineer — AI copilots, decentralized systems, and personal knowled
 **Now**
 - AI copilot for customer-support teams — LLM reply generation with guardrails (PII masking, hallucination detection)
 - [Monas](https://github.com/Monas-project/monas) — decentralized personal data store (Rust)
-- Obsidian × AI — personal knowledge base, [clippings dedupe](https://github.com/somasekimoto/obsidian-clippings-dedupe), X auto-archiving
+- Obsidian tooling — [clippings dedupe](https://github.com/somasekimoto/obsidian-clippings-dedupe), X auto-archiving
 - Automating my solo business with AI agents
 
 **Stack**

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Soma Sekimoto
 
-Full-stack engineer — decentralized systems, personal knowledge tools, and AI-powered automation.
+Full-stack engineer — AI copilots, decentralized systems, and personal knowledge tools.
 
 **Now**
+- AI copilot for customer-support teams — LLM reply generation with guardrails (PII masking, hallucination detection)
 - [Monas](https://github.com/Monas-project/monas) — decentralized personal data store (Rust)
-- Obsidian × AI — [obsidian-clippings-dedupe](https://github.com/somasekimoto/obsidian-clippings-dedupe), X→Obsidian auto-archiving, building a personal knowledge base AI can work with
-- Automating my solo business (accounting, ops) with AI agents
+- Obsidian × AI — personal knowledge base, [clippings dedupe](https://github.com/somasekimoto/obsidian-clippings-dedupe), X auto-archiving
+- Automating my solo business with AI agents
 
 **Stack**
-Rust · TypeScript · Go · Python · React / Next.js · Cloudflare Workers · Docker / K8s
+TypeScript · Rust · Go · Python · React / Next.js · Terraform · Cloudflare Workers
 
 **Links**
 [X](https://x.com/somaseki) · [Zenn](https://zenn.dev/somasekimoto) · [Qiita](https://qiita.com/soma_sekimoto)

--- a/README.md
+++ b/README.md
@@ -1,68 +1,12 @@
-```
-                              ┌─────────────────────────────────┐
-                              │  $ whoami                       │
-                              │  > Soma Sekimoto                │
-                              │  $ pwd                          │
-                              │  > /dev/web3/fullstack          │
-                              └─────────────────────────────────┘
-```
+# Soma Sekimoto
 
-[![Typing SVG](https://readme-typing-svg.herokuapp.com?font=Fira+Code&pause=1000&color=00FF00&background=000000&width=435&lines=Web3+%2F+Blockchain+Engineer;Full+Stack+Developer;Cryptography+Enthusiast)](https://git.io/typing-svg)
+Full-stack engineer — Web3, cryptography, and privacy tech.
 
-## Current Focus
+**Now**
+Fully Homomorphic Encryption (TFHE) · Zero-Knowledge Proofs
 
-```bash
-$ tail -f ~/current.log
-```
+**Stack**
+Go · TypeScript · Rust · Solidity · React / Next.js · Docker / K8s
 
-```
-[2025] → Fully Homomorphic Encryption (TFHE)
-[2025] → Zero-Knowledge Proofs & Privacy Tech
-[2024] → Smart Contract Development (Solidity)
-[2024] → Decentralized Systems Architecture
-```
-
-## Tech Stack
-
-```bash
-$ tree ~/stack --depth=1
-```
-
-```
-stack/
-├── blockchain/    [Solidity, Geth, Hardhat, ethers.js]
-├── crypto/        [Rust, TFHE, ZK-SNARKs, Lit Protocol]
-├── backend/       [Go, TypeScript, gRPC/Connect]
-├── frontend/      [React, Next.js, Web3.js]
-└── infra/         [Docker, K8s, IPFS]
-```
-
-## Stats
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                                                                  │
-│  Contributions: ████████████████████░░░░ 72%                    │
-│  Code Reviews:  ██████████████░░░░░░░░░ 58%                     │
-│  Open Source:   ███████████████████░░░░ 81%                     │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
-```
-
-![GitHub Stats](https://github-readme-stats.vercel.app/api?username=somasekimoto&show_icons=true&theme=terminal&hide_border=true&bg_color=000000&title_color=00ff00&text_color=00ff00&icon_color=00ff00)
-
-## Connect
-
-```bash
-$ echo "contact" | base64 -d
-```
-
-[![GitHub](https://img.shields.io/badge/GitHub-000000?style=flat-square&logo=github&logoColor=white)](https://github.com/somasekimoto)
-[![Qiita](https://img.shields.io/badge/Qiita-55C500?style=flat-square&logo=qiita&logoColor=white)](https://qiita.com/soma_sekimoto)
-[![Zenn](https://img.shields.io/badge/Zenn-3EA8FF?style=flat-square&logo=zenn&logoColor=white)](https://zenn.dev/somasekimoto)
-
----
-
-```
-EOF
-```
+**Writing**
+[Zenn](https://zenn.dev/somasekimoto) · [Qiita](https://qiita.com/soma_sekimoto)


### PR DESCRIPTION
## What
プロフィールREADMEを装飾なしのミニマル構成に置き換え。

- 削除: ターミナル風ASCIIアート、typing SVG(Herokuホストで不安定)、自己申告プログレスバー(72%等)、shields.ioバッジ列、`base64`ネタ、GitHub statsカード
- 残したもの: 一行の自己紹介、Now(TFHE / ZKP)、Stack、Zenn・Qiitaリンク(プレーンテキストリンク化)

## Notes
- GitHub statsカードを残したければ1枚だけ戻すのもあり
- 後段でZenn/QiitaのRSS自動埋め込み(GitHub Actions)を足す場合も、この構成ならセクションを1つ追加するだけで済む

🤖 Generated with [Claude Code](https://claude.com/claude-code)